### PR TITLE
feat: `clientType` option

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,11 +1,11 @@
 import { getOAuthAccessToken } from "./get-oauth-access-token";
-import { State, AuthOptions, Authentication } from "./types";
+import { State, AuthOptions, Authentication, ClientType } from "./types";
 
-export async function auth(
+export async function auth<TClientType extends ClientType>(
   state: State,
   authOptions: AuthOptions
-): Promise<Authentication> {
-  return getOAuthAccessToken(state, {
+): Promise<Authentication<TClientType>> {
+  return getOAuthAccessToken<TClientType>(state, {
     auth: authOptions,
   });
 }

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -7,10 +7,10 @@ import {
 } from "@octokit/types";
 
 import { getOAuthAccessToken } from "./get-oauth-access-token";
-import { State } from "./types";
+import { ClientType, State } from "./types";
 import { EndpointDefaults } from "@octokit/types";
 
-export async function hook(
+export async function hook<TClientType extends ClientType>(
   state: State,
   request: RequestInterface,
   route: Route | EndpointOptions,
@@ -26,7 +26,7 @@ export async function hook(
     return request(endpoint);
   }
 
-  const { token } = await getOAuthAccessToken(state, {
+  const { token } = await getOAuthAccessToken<TClientType>(state, {
     request,
     auth: { type: "oauth" },
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,32 +1,59 @@
 import { getUserAgent } from "universal-user-agent";
-import { request } from "@octokit/request";
+import { request as octokitRequest } from "@octokit/request";
+import {
+  RequestInterface,
+  EndpointOptions,
+  RequestParameters,
+  Route,
+} from "@octokit/types";
 
 import { auth } from "./auth";
 import { hook } from "./hook";
 import * as Types from "./types";
 import { VERSION } from "./version";
 
-export type StrategyOptions = Types.StrategyOptions;
-export type AuthOptions = Types.AuthOptions;
-export type Authentication = Types.Authentication;
-export type OAuthAppAuthentication = Types.OAuthAppAuthentication;
-export type GitHubAppAuthentication = Types.GitHubAppAuthentication;
-export type GitHubAppAuthenticationWithExpiration = Types.GitHubAppAuthenticationWithExpiration;
+export {
+  StrategyOptions,
+  AuthOptions,
+  Authentication,
+  OAuthAppAuthentication,
+  GitHubAppAuthentication,
+  GitHubAppAuthenticationWithExpiration,
+} from "./types";
 
-export function createOAuthDeviceAuth(
-  options: Types.StrategyOptions
-): Types.AuthInterface {
-  const state = Object.assign(
-    {
-      request: request.defaults({
-        headers: {
-          "user-agent": `octokit-auth-oauth-device.js/${VERSION} ${getUserAgent()}`,
-        },
-      }),
-      scopes: [],
-    },
-    options
-  );
+export function createOAuthDeviceAuth<
+  TClientType extends Types.ClientType = "oauth-app"
+>(
+  options: Types.StrategyOptions<TClientType>
+): Types.AuthInterface<TClientType> {
+  const requestWithDefaults =
+    options.request ||
+    octokitRequest.defaults({
+      headers: {
+        "user-agent": `octokit-auth-oauth-device.js/${VERSION} ${getUserAgent()}`,
+      },
+    });
+
+  const {
+    request = requestWithDefaults,
+    clientType = "oauth-app",
+    scopes = [],
+    ...otherOptions
+  } = options;
+
+  const state: Types.State =
+    clientType === "github-app"
+      ? {
+          clientType,
+          request,
+          ...otherOptions,
+        }
+      : {
+          clientType,
+          request,
+          scopes,
+          ...otherOptions,
+        };
 
   if (!options.clientId) {
     throw new Error(
@@ -40,7 +67,14 @@ export function createOAuthDeviceAuth(
     );
   }
 
-  return Object.assign(auth.bind(null, state), {
-    hook: hook.bind(null, state),
-  });
+  return Object.assign(
+    (options: Types.AuthOptions) => auth<TClientType>(state, options),
+    {
+      hook: (
+        request: RequestInterface,
+        route: Route | EndpointOptions,
+        parameters: RequestParameters
+      ) => hook(state, request, route, parameters),
+    }
+  );
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -122,7 +122,6 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
         },
         body: {
           client_id: "lv1.1234567890abcdef",
-          scope: "",
         },
       }
     )
@@ -175,7 +174,7 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
 
   const onVerification = jest.fn();
   const auth = createOAuthDeviceAuth({
-    // "lv1." prefix only exists for GitHub Apps
+    clientType: "github-app",
     clientId: "lv1.1234567890abcdef",
     onVerification,
     request: request.defaults({
@@ -225,7 +224,6 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
         },
         body: {
           client_id: "lv1.1234567890abcdef",
-          scope: "",
         },
       }
     )
@@ -281,7 +279,7 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
 
   const onVerification = jest.fn();
   const auth = createOAuthDeviceAuth({
-    // "lv1." prefix only exists for GitHub Apps
+    clientType: "github-app",
     clientId: "lv1.1234567890abcdef",
     onVerification,
     request: request.defaults({
@@ -727,7 +725,6 @@ test("does not refresh token for GitHub Apps", async () => {
         },
         body: {
           client_id: "lv1.1234567890abcdef",
-          scope: "",
         },
       }
     )
@@ -798,6 +795,7 @@ test("does not refresh token for GitHub Apps", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
+    clientType: "github-app",
     clientId: "lv1.1234567890abcdef",
     onVerification: jest.fn(),
     request: request.defaults({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -24,7 +24,7 @@ test("README example", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -43,7 +43,7 @@ test("README example", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -62,7 +62,7 @@ test("README example", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -72,7 +72,7 @@ test("README example", async () => {
 
   const onVerification = jest.fn();
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification,
     request: request.defaults({
       headers: {
@@ -89,7 +89,7 @@ test("README example", async () => {
   });
 
   expect(await authentication).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -121,7 +121,7 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           scope: "",
         },
       }
@@ -140,7 +140,7 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -165,7 +165,7 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -176,7 +176,7 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
   const onVerification = jest.fn();
   const auth = createOAuthDeviceAuth({
     // "lv1." prefix only exists for GitHub Apps
-    clientId: "lv1.123",
+    clientId: "lv1.1234567890abcdef",
     onVerification,
     request: request.defaults({
       headers: {
@@ -196,7 +196,7 @@ test("README example for GitHub App with expiring tokens disabled", async () => 
     type: "token",
     tokenType: "oauth",
     clientType: "github-app",
-    clientId: "lv1.123",
+    clientId: "lv1.1234567890abcdef",
     token: "token123",
   });
 
@@ -224,7 +224,7 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           scope: "",
         },
       }
@@ -243,7 +243,7 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -271,7 +271,7 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -282,7 +282,7 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
   const onVerification = jest.fn();
   const auth = createOAuthDeviceAuth({
     // "lv1." prefix only exists for GitHub Apps
-    clientId: "lv1.123",
+    clientId: "lv1.1234567890abcdef",
     onVerification,
     request: request.defaults({
       headers: {
@@ -302,7 +302,7 @@ test("README example for GitHub App with expiring tokens enabled", async () => {
     type: "token",
     tokenType: "oauth",
     clientType: "github-app",
-    clientId: "lv1.123",
+    clientId: "lv1.1234567890abcdef",
     token: "token123",
     expiresAt: "1970-01-01T08:00:00.000Z",
     refreshToken: "r1.token123",
@@ -330,14 +330,14 @@ test("Request for user/device code fails", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -377,7 +377,7 @@ test("Caches token", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -395,7 +395,7 @@ test("Caches token", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -404,7 +404,7 @@ test("Caches token", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -421,7 +421,7 @@ test("Caches token", async () => {
   });
 
   expect(authentication1).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -458,7 +458,7 @@ test("auth({ refresh: true })", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -476,7 +476,7 @@ test("auth({ refresh: true })", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -502,7 +502,7 @@ test("auth({ refresh: true })", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
         overwriteRoutes: false,
@@ -521,7 +521,7 @@ test("auth({ refresh: true })", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode456",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -530,7 +530,7 @@ test("auth({ refresh: true })", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -547,7 +547,7 @@ test("auth({ refresh: true })", async () => {
   });
 
   expect(authentication1).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -561,7 +561,7 @@ test("auth({ refresh: true })", async () => {
   });
 
   expect(authentication2).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -592,7 +592,7 @@ test("refreshes token for different scopes", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -610,7 +610,7 @@ test("refreshes token for different scopes", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -636,7 +636,7 @@ test("refreshes token for different scopes", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "repo",
         },
         overwriteRoutes: false,
@@ -655,7 +655,7 @@ test("refreshes token for different scopes", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode456",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -664,7 +664,7 @@ test("refreshes token for different scopes", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -681,7 +681,7 @@ test("refreshes token for different scopes", async () => {
   });
 
   expect(authentication1).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -695,7 +695,7 @@ test("refreshes token for different scopes", async () => {
   });
 
   expect(authentication2).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -726,7 +726,7 @@ test("does not refresh token for GitHub Apps", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           scope: "",
         },
       }
@@ -744,7 +744,7 @@ test("does not refresh token for GitHub Apps", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -770,7 +770,7 @@ test("does not refresh token for GitHub Apps", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           scope: "repo",
         },
         overwriteRoutes: false,
@@ -789,7 +789,7 @@ test("does not refresh token for GitHub Apps", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "lv1.123",
+          client_id: "lv1.1234567890abcdef",
           device_code: "devicecode456",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -798,7 +798,7 @@ test("does not refresh token for GitHub Apps", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "lv1.123",
+    clientId: "lv1.1234567890abcdef",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -815,7 +815,7 @@ test("does not refresh token for GitHub Apps", async () => {
   });
 
   expect(authentication1).toEqual({
-    clientId: "lv1.123",
+    clientId: "lv1.1234567890abcdef",
     clientType: "github-app",
     type: "token",
     tokenType: "oauth",
@@ -851,7 +851,7 @@ test("test with request instance that has custom baseUrl (GHE)", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -869,7 +869,7 @@ test("test with request instance that has custom baseUrl (GHE)", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -878,7 +878,7 @@ test("test with request instance that has custom baseUrl (GHE)", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       baseUrl: "https://github.acme-inc.com/api/v3",
@@ -894,7 +894,7 @@ test("test with request instance that has custom baseUrl (GHE)", async () => {
   const authentication = await auth({ type: "oauth" });
 
   expect(authentication).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -926,7 +926,7 @@ test("slow_down error", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -945,7 +945,7 @@ test("slow_down error", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -964,7 +964,7 @@ test("slow_down error", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -973,7 +973,7 @@ test("slow_down error", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -990,7 +990,7 @@ test("slow_down error", async () => {
   });
 
   expect(await authentication).toEqual({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     clientType: "oauth-app",
     type: "token",
     tokenType: "oauth",
@@ -1022,7 +1022,7 @@ test("expired_token error", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -1041,7 +1041,7 @@ test("expired_token error", async () => {
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -1049,7 +1049,7 @@ test("expired_token error", async () => {
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
     request: request.defaults({
       headers: {
@@ -1087,7 +1087,7 @@ test("auth.hook() creates token and uses it for succeeding requests", async () =
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           scope: "",
         },
       }
@@ -1105,7 +1105,7 @@ test("auth.hook() creates token and uses it for succeeding requests", async () =
           "content-type": "application/json; charset=utf-8",
         },
         body: {
-          client_id: "123",
+          client_id: "1234567890abcdef1234",
           device_code: "devicecode123",
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
         },
@@ -1114,7 +1114,7 @@ test("auth.hook() creates token and uses it for succeeding requests", async () =
     )
     .get(
       "https://api.github.com/user",
-      { id: 123 },
+      { id: "1234567890abcdef1234" },
       {
         headers: {
           authorization: "token secret123",
@@ -1124,7 +1124,7 @@ test("auth.hook() creates token and uses it for succeeding requests", async () =
     );
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
   });
 
@@ -1160,7 +1160,7 @@ test("auth.hook(request, 'POST https://github.com/login/oauth/access_token') doe
     });
 
   const auth = createOAuthDeviceAuth({
-    clientId: "123",
+    clientId: "1234567890abcdef1234",
     onVerification: jest.fn(),
   });
 
@@ -1199,7 +1199,7 @@ test("onVerification option not set", () => {
   expect(() =>
     // @ts-expect-error property 'onVerification' is missing
     createOAuthDeviceAuth({
-      clientId: "123",
+      clientId: "1234567890abcdef1234",
     })
   ).toThrow(
     `[@octokit/auth-oauth-device] "onVerification" option must be a function (https://github.com/octokit/auth-oauth-device.js#usage)`


### PR DESCRIPTION
BREAKING CHANGE: `clientType` is no longer derived automatically from `clientId`. Instead set the `clientType` strategy option to `"github-app"` explicitly for GitHub Apps. The new option defaults to `"oauth-app"`.