### PR TITLE
fix(test): force test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         run: npm test --ignore-scripts # run lint only once
   test:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     needs: test_matrix
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
     if: ${{ always() }}
     needs: test_matrix
     steps:
+      - run: exit 1
+        if: ${{ needs.test_matrix.result != 'success' }}
+
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
# Description

Assure 'test' Check Run is always executed and `fails`/`succeeds` accordingly to the results of its dependency jobs.

- Example commit with all tests passing ✅: c4a2c50e7eb30baa6b3fb54c75e3c31429c591ed
- Example commit with tests failing 🔴: 8d93278aa268be6706f97c973a17d3d05cbac53f

---
# Context
When using `job.needs`, [by default only runs when the dependency jobs succeed](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds). If one or more of them fail, the dependent job is **skipped**