### PR TITLE
maint: Updated to the new types from deprecated types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -68,12 +68,12 @@ export type OAuthAppAuthentication = {
 export type GitHubAppAuthentication = {
   type: "token";
   tokenType: "oauth";
-} & Omit<OAuthMethodsTypes.GitHubAppAuthentication, "clientSecret">;
+} & Omit<OAuthMethodsTypes.GitHubAppAuthenticationWithExpirationDisabled, "clientSecret">;
 
 export type GitHubAppAuthenticationWithExpiration = {
   type: "token";
   tokenType: "oauth";
-} & Omit<OAuthMethodsTypes.GitHubAppAuthentication, "clientSecret">;
+} & Omit<OAuthMethodsTypes.GitHubAppAuthenticationWithRefreshToken, "clientSecret">;
 
 export type Verification = {
   device_code: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,12 +68,18 @@ export type OAuthAppAuthentication = {
 export type GitHubAppAuthentication = {
   type: "token";
   tokenType: "oauth";
-} & Omit<OAuthMethodsTypes.GitHubAppAuthenticationWithExpirationDisabled, "clientSecret">;
+} & Omit<
+  OAuthMethodsTypes.GitHubAppAuthenticationWithExpirationDisabled,
+  "clientSecret"
+>;
 
 export type GitHubAppAuthenticationWithExpiration = {
   type: "token";
   tokenType: "oauth";
-} & Omit<OAuthMethodsTypes.GitHubAppAuthenticationWithRefreshToken, "clientSecret">;
+} & Omit<
+  OAuthMethodsTypes.GitHubAppAuthenticationWithRefreshToken,
+  "clientSecret"
+>;
 
 export type Verification = {
   device_code: string;


### PR DESCRIPTION
Updated `GitHubAppAuthentication` and `GitHubAppAuthenticationWithExpiration` types to the new types.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->

Initially put the wrong issue reference (typo) ~~Resolves #163~~

Resolves #162 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
The updated types were using the `GitHubAppAuthentication` type in `oauth-methods`, which is deprecated.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The types now use the appropriate updated types:
- `GitHubAppAuthenticationWithExpirationDisabled`
- `GitHubAppAuthenticationWithRefreshToken`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No, as the new types add options and don't remove any.

