### PR TITLE
fix(deps): bump Octokit deps to fix Deno compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/oauth-methods": "^5.0.0",
-        "@octokit/request": "^9.0.0",
-        "@octokit/types": "^13.0.0",
+        "@octokit/oauth-methods": "^5.1.3",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "devDependencies": {
@@ -1568,15 +1568,15 @@
       }
     },
     "node_modules/@octokit/oauth-methods": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.2.tgz",
-      "integrity": "sha512-C5lglRD+sBlbrhCUTxgJAFjWgJlmTx5bQ7Ch0+2uqRjYv7Cfb5xpX4WuSC9UgQna3sqRGBL9EImX9PvTpMaQ7g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.3.tgz",
+      "integrity": "sha512-M+bDBi5H8FnH0xhCTg0m9hvcnppdDnxUqbZyOkxlLblKpLAR+eT2nbDPvJDp0eLrvJWA1I8OX0KHf/sBMQARRA==",
       "license": "MIT",
       "dependencies": {
         "@octokit/oauth-authorization-url": "^7.0.0",
-        "@octokit/request": "^9.1.0",
-        "@octokit/request-error": "^6.1.0",
-        "@octokit/types": "^13.0.0"
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2"
       },
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
   "author": "Gregor Martynus (https://dev.to/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/oauth-methods": "^5.0.0",
-    "@octokit/request": "^9.0.0",
-    "@octokit/types": "^13.0.0",
+    "@octokit/oauth-methods": "^5.1.3",
+    "@octokit/request": "^9.1.4",
+    "@octokit/types": "^13.6.2",
     "universal-user-agent": "^7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://github.com/octokit/octokit.js/issues/2762#issuecomment-2486997620

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Types would include a reference to `@types/node` even though there is nothing using Node specific APIs in the types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Update `@octokit/types` to make sure types are platform agnostic
* Update all Octokit types to the version that includes the fixed types

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

