### PR TITLE
fix: increase interval auxiliar value to 7

### DIFF
--- a/src/get-oauth-access-token.ts
+++ b/src/get-oauth-access-token.ts
@@ -124,7 +124,7 @@ async function waitForAccessToken(
     }
 
     if (errorType === "slow_down") {
-      await wait(verification.interval + 5);
+      await wait(verification.interval + 7);
       return waitForAccessToken(request, clientId, clientType, verification);
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #334 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->
I am increasing the auxiliar number in `await wait(verification.interval + 5);` to `await wait(verification.interval + 7);` because it was causing `slow_down` errors with Github's API. This was causing a freeze in the authentication flow because the access token was never returned (instead we were getting `slow_down` messages)

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Now it does not stop the authentication flow and we only wait 2 seconds more

### Pull request checklist
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->
No

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [X] Yes
- [ ] No

----

